### PR TITLE
Revert "Bump actions/checkout from 3 to 4"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
actions/checkout v4 seems to be making my tests flakey